### PR TITLE
fix: resolve iPhone Safari button loading issue

### DIFF
--- a/src/modules/login/hooks.ts
+++ b/src/modules/login/hooks.ts
@@ -28,6 +28,14 @@ export const useLoginState = () => {
   const { data, isValidating } = useSWR<PersonalUserDetailView, Error>(
     firebaseUser ? `/api/users/${firebaseUser.uid}?detailed=true` : null,
     fetcher,
+    {
+      // fixes mobile safari isValidating stuck problem
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+      errorRetryInterval: 10000,
+      loadingTimeout: 5000,
+    }
   );
   const login = async () => {
     const provider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
- Fixed SWR `isValidating` stuck on `true` in iPhone Safari causing buttons to remain disabled
- Added SWR configuration to prevent automatic revalidation triggers that cause problems on mobile Safari
- Configured proper timeout and retry settings for better mobile network handling

## Changes
- Modified `src/modules/login/hooks.ts` to add SWR configuration options:
  - `revalidateOnFocus: false` - prevents revalidation on tab focus changes
  - `revalidateOnReconnect: false` - prevents revalidation on network reconnections
  - `revalidateIfStale: false` - prevents automatic revalidation of stale data
  - `errorRetryInterval: 10000` - sets retry interval to 10 seconds
  - `loadingTimeout: 5000` - sets loading timeout to 5 seconds

## Test plan
- [ ] Test login button functionality on iPhone Safari
- [ ] Verify buttons are not stuck in loading state
- [ ] Test on other mobile browsers for compatibility
- [ ] Verify desktop Safari still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)