### PR TITLE
fix: replace API fetch with direct repository calls in getStaticProps

### DIFF
--- a/src/pages/targets/[targetId]/index.tsx
+++ b/src/pages/targets/[targetId]/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@/components/ui/layout";
-import { Button } from "@/components/ui/button";
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { useRouter } from "next/router";
 import LoadError from "../../../components/element/loadException/loadError";
@@ -8,13 +7,15 @@ import MetaHeader from "../../../components/pages/metaHeader";
 import TabbedNamingDetailList from "../../../components/pages/target/namings/tabbedNamingDetailList";
 import TargetDetail from "../../../components/pages/target/targetDetail";
 import {
-  NamingTarget,
   NamingTargetForView,
   NamingTargetListGenre,
 } from "../../../models/namingTarget";
 import { useLoginState } from "../../../modules/login/hooks";
 import { useNamingTarget } from "../../../modules/namingTarget/hooks";
 import { ActionButton } from "@/components/element/actionButton";
+import namingTargetRepository from "../../../repositories/namingTarget";
+import imageRepository from "../../../repositories/image/firebase";
+import Constants from "../../../constants";
 
 type Props = {
   ogpTarget: NamingTargetForView;
@@ -82,14 +83,21 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
     };
   }
   try {
-    const target: NamingTargetForView = await (
-      await fetch(
-        `${process.env.VERCEL_URL_PROTOCOL}${process.env.VERCEL_URL}/api/targets/${targetId}`,
-      )
-    ).json();
+    const target = await namingTargetRepository.get(targetId);
+    const targetForView: NamingTargetForView = {
+      id: target.id,
+      authorId: target.authorId,
+      title: target.title,
+      comment: target.comment,
+      imageUrl: target.imageId
+        ? await imageRepository.resolveUrl(target.imageId)
+        : undefined,
+      evalCounts: target.evalCounts,
+      isDeleted: target.isDeleted,
+    };
     return {
       props: {
-        ogpTarget: target,
+        ogpTarget: targetForView,
       },
       revalidate: 60,
     };
@@ -102,11 +110,11 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
 
 export const getStaticPaths: GetStaticPaths = async () => {
   try {
-    const targets: NamingTarget[] = await (
-      await fetch(
-        `${process.env.VERCEL_URL_PROTOCOL}${process.env.VERCEL_URL}/api/targets?genre=${NamingTargetListGenre.LATEST}&page=1`,
-      )
-    ).json();
+    const targets = await namingTargetRepository.list(
+      Constants.namingTargetsPageCount,
+      NamingTargetListGenre.LATEST,
+      1,
+    );
     return {
       paths: targets.map((t) => `/targets/${t.id}`),
       fallback: true,

--- a/src/pages/users/[userId]/index.tsx
+++ b/src/pages/users/[userId]/index.tsx
@@ -5,6 +5,8 @@ import LoadingContent from "../../../components/pages/loading";
 import MetaHeader from "../../../components/pages/metaHeader";
 import UserDetail from "../../../components/pages/users/userDetail";
 import { PersonalUserDetailView } from "../../../models/personalUser";
+import personalUserRepository from "../../../repositories/personalUser";
+import imageRepository from "../../../repositories/image/firebase";
 
 type Props = {
   user: PersonalUserDetailView;
@@ -35,11 +37,22 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
     };
   }
   try {
-    const user: PersonalUserDetailView = await (
-      await fetch(
-        `${process.env.VERCEL_URL_PROTOCOL}${process.env.VERCEL_URL}/api/users/${userId}?detailed=true`,
-      )
-    ).json();
+    const personalUser = await personalUserRepository.get(userId);
+    if (!personalUser) {
+      return { notFound: true };
+    }
+    const imageUrl = personalUser.iconImageId
+      ? await imageRepository.resolveUrl(personalUser.iconImageId)
+      : undefined;
+    const user: PersonalUserDetailView = {
+      id: personalUser.id,
+      name: personalUser.name,
+      userId: personalUser.userId,
+      imageUrl,
+      profile: personalUser.profile,
+      url: personalUser.url,
+      twitterUserId: personalUser.twitterUserId,
+    };
     return {
       props: {
         user,


### PR DESCRIPTION
## Summary
- Replace self-API fetch calls with direct repository usage in `getStaticProps` / `getStaticPaths`
- Fix build/ISR regeneration failures when Vercel Authentication is enabled
- Affected files: `src/pages/targets/[targetId]/index.tsx`, `src/pages/users/[userId]/index.tsx`

## Test plan
- [x] Verify `npm run build` succeeds locally
- [x] Verify `/targets/{targetId}` page displays correctly locally
- [x] Verify `/users/{userId}` page displays correctly locally
- [x] Verify pages don't return 404 with Vercel Authentication enabled after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ScreenShots (Test logs)
**user page**
<img width="723" height="133" alt="user-page" src="https://github.com/user-attachments/assets/09c325b4-0ffb-46e3-a10c-d49252a3babf" />

**target page**
<img width="622" height="189" alt="target-page" src="https://github.com/user-attachments/assets/e0aeede7-a563-49ff-b890-8702118942f7" />
